### PR TITLE
MixEval: avoid writing response_rank0 

### DIFF
--- a/eval/chat_benchmarks/MixEval/eval_instruct.py
+++ b/eval/chat_benchmarks/MixEval/eval_instruct.py
@@ -161,9 +161,6 @@ class MixEvalBenchmark(BaseBenchmark):
         self.args.split = split
         self.args.model_name = self._get_model_name(model)
         response_file = self._get_response_file()
-        if model.world_size > 1:
-            # Add GPU rank to filename to avoid conflicts
-            response_file = response_file.replace(".jsonl", f"_rank{model.rank}.jsonl")
 
         eval_dataset = get_eval_dataset(self.args)
 


### PR DESCRIPTION
tested on 8 GPUs:
 "llama_31_8b_instruct": {
        "BoolQ": 0.829,
        "MBPP": 0.0,
        "HellaSwag": 0.643,
        "OpenBookQA": 0.841,
        "MATH": 0.54,
        "overall": 0.7364999999999999,
        "MMLU": 0.716,
        "BBH": 0.67,
        "ARC": 0.87,
        "GPQA": 0.25,
        "AGIEval": 0.5296923076923077,
        "SIQA": 0.684,
        "TriviaQA": 0.733,
        "CommonsenseQA": 0.759,
        "PIQA": 0.854,
        "WinoGrande": 0.0,
        "DROP": 0.802,
        "GSM8k": 0.847
    }