### PR TITLE
Support reading from eval config yamls

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ To choose a model, simply set 'pretrained=<name of hf model>' where the model na
 #### Coming Soon
 - Support for [vLLM models](https://vllm.ai/)
 - Support for [OpenAI](https://openai.com/)
+- Few-shot prompting for instruction benchmarks.
 
 ### Multi-GPU Evaluation
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ python -m eval.eval \
     --output_path logs
 ```
 
+**Config shortcuts**: 
+
+To be able to reuse commonly used settings without having to manually supply full arguments every time, we support reading eval configs from YAML files. These configs replace the `--batch_size`, `--tasks`, and `--annoator_model` arguments. Some example config files can be found in `./configs`. To use these configs, you can use the `--config` flag as shown below:
+
+```bash
+python -m eval.eval \
+    --model hf \
+    --model_args "pretrained=mistralai/Mistral-7B-Instruct-v0.3" \
+    --output_path logs \
+    --config configs/light_gpt4omini0718.yaml
+```
+
 We add several more command examples in [`eval/examples`](https://github.com/mlfoundations/Evalchemy/tree/main/eval/examples) to help you start using Evalchemy. 
 
 ## 🔧 Advanced Usage

--- a/configs/full_gpt4omini0718.yaml
+++ b/configs/full_gpt4omini0718.yaml
@@ -1,0 +1,26 @@
+annotator_model: gpt-4o-mini-2024-07-18
+tasks:
+  - task_name: alpaca_eval
+    batch_size: 32
+  - task_name: WildBench
+    batch_size: 16
+  - task_name: MixEval
+    batch_size: 32
+  - task_name: MTBench
+    batch_size: 32
+  - task_name: RepoBench
+    batch_size: 8
+  - task_name: zeroeval
+    batch_size: 8
+  - task_name: IFEval
+    batch_size: 32
+  - task_name: mmlu
+    batch_size: 32
+  - task_name: ai2_arc
+    batch_size: 32
+  - task_name: HumanEval
+    batch_size: 32
+  - task_name: MBPP
+    batch_size: 32
+  - task_name: drop
+    batch_size: 32

--- a/configs/light_gpt4omini0718.yaml
+++ b/configs/light_gpt4omini0718.yaml
@@ -1,0 +1,10 @@
+annotator_model: gpt-4o-mini-2024-07-18
+tasks:
+  - task_name: alpaca_eval
+    batch_size: 32
+  - task_name: WildBench
+    batch_size: 16
+  - task_name: MixEval
+    batch_size: 32
+  - task_name: MTBench
+    batch_size: 32

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -291,14 +291,6 @@ def cli_evaluate(args: Optional[argparse.Namespace] = None) -> None:
         task_list=task_list,
         verbosity=args.verbosity,
         args=args,
-        num_fewshot=args.num_fewshot,
-        batch_size=args.batch_size,
-        max_batch_size=args.max_batch_size,
-        device=args.device,
-        use_cache=args.use_cache,
-        limit=args.limit,
-        annotator_model=args.annotator_model,
-        evaluation_tracker=evaluation_tracker,
     )
 
     # Add metadata to results

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import time
+import yaml
 from typing import Optional, List, Dict, Union
 
 import concurrent.futures
@@ -73,6 +74,11 @@ def setup_custom_parser():
     )
 
     parser.add_argument(
+        "--config",
+        type=str,
+        help="Path to config yaml. Overwrites --batch_size, --tasks, and --annotator_model"
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Run evalutaions in debug mode on a few examples",
@@ -85,6 +91,7 @@ def evaluate(
     task_manager: InstructTaskManager,
     pretrain_task_manager: PretrainTaskManager,
     task_list: List[str],
+    batch_sizes_list: List[int],
     verbosity: str = "INFO",
     args=None,
     **eval_kwargs,
@@ -101,6 +108,8 @@ def evaluate(
             Manager for pre-training evaluation tasks.
         task_list (List[str]):
             List of task names to evaluate the model on.
+        batch_sizes_list (List[int]):
+            List of batch sizes for each task.
         verbosity (str, optional):
             Logging verbosity level. Defaults to "INFO".
         args (Any, optional):
@@ -118,7 +127,9 @@ def evaluate(
 
     # Split tasks between benchmark and pretrain
     benchmark_tasks = [t for t in task_list if t in task_manager.tasks]
+    benchmark_batch_sizes = [b for (t,b) in zip(task_list, batch_sizes_list) if t in task_manager.tasks]
     pretrain_tasks = [t for t in task_list if t in pretrain_task_manager.all_tasks]
+    pretrain_batch_sizes = [b for (t,b) in zip(task_list, batch_sizes_list) if t in pretrain_task_manager.all_tasks]
 
     unknown_tasks = set(task_list).difference(set(benchmark_tasks)).difference(set(pretrain_tasks))
 
@@ -138,7 +149,8 @@ def evaluate(
         generate_methods = task_manager.get_list_generate_responses(benchmark_tasks)
         generation_results = []
         valid_tasks = []  # Keep track of valid tasks
-        for method, task in zip(generate_methods, benchmark_tasks):
+        for method, task, batch_size in zip(generate_methods, benchmark_tasks, benchmark_batch_sizes):
+            lm.batch_size_per_gpu = batch_size
             result = method(lm)
             if result is not None:  # Only keep valid results and their corresponding tasks
                 generation_results.append(result)
@@ -163,34 +175,35 @@ def evaluate(
     # Run pretrain evaluations if any exist
     if pretrain_tasks and args is not None:
         try:
-            pretrain_results = pretrain_evaluator.simple_evaluate(
-                model=args.model,
-                model_args=args.model_args,
-                tasks=pretrain_tasks,
-                num_fewshot=args.num_fewshot,
-                batch_size=args.batch_size,
-                max_batch_size=args.max_batch_size,
-                device=args.device,
-                use_cache=args.use_cache,
-                limit=args.limit,
-                check_integrity=args.check_integrity,
-                write_out=args.write_out,
-                log_samples=args.log_samples,
-                evaluation_tracker=args.evaluation_tracker if hasattr(args, "evaluation_tracker") else None,
-                system_instruction=args.system_instruction,
-                apply_chat_template=args.apply_chat_template,
-                fewshot_as_multiturn=args.fewshot_as_multiturn,
-                gen_kwargs=args.gen_kwargs,
-                task_manager=pretrain_task_manager,
-                verbosity=args.verbosity,
-                predict_only=args.predict_only,
-                random_seed=args.seed[0] if hasattr(args, "seed") else None,
-                numpy_random_seed=args.seed[1] if hasattr(args, "seed") else None,
-                torch_random_seed=args.seed[2] if hasattr(args, "seed") else None,
-                fewshot_random_seed=args.seed[3] if hasattr(args, "seed") else None,
-            )
-            if pretrain_results is not None:
-                results["results"].update(pretrain_results.get("results", {}))
+            for pretrain_task, batch_size in zip(pretrain_tasks, pretrain_batch_sizes):
+                pretrain_results = pretrain_evaluator.simple_evaluate(
+                    model=args.model,
+                    model_args=args.model_args,
+                    tasks=[pretrain_task],
+                    num_fewshot=args.num_fewshot,
+                    batch_size=batch_size,
+                    max_batch_size=args.max_batch_size,
+                    device=args.device,
+                    use_cache=args.use_cache,
+                    limit=args.limit,
+                    check_integrity=args.check_integrity,
+                    write_out=args.write_out,
+                    log_samples=args.log_samples,
+                    evaluation_tracker=args.evaluation_tracker if hasattr(args, "evaluation_tracker") else None,
+                    system_instruction=args.system_instruction,
+                    apply_chat_template=args.apply_chat_template,
+                    fewshot_as_multiturn=args.fewshot_as_multiturn,
+                    gen_kwargs=args.gen_kwargs,
+                    task_manager=pretrain_task_manager,
+                    verbosity=args.verbosity,
+                    predict_only=args.predict_only,
+                    random_seed=args.seed[0] if hasattr(args, "seed") else None,
+                    numpy_random_seed=args.seed[1] if hasattr(args, "seed") else None,
+                    torch_random_seed=args.seed[2] if hasattr(args, "seed") else None,
+                    fewshot_random_seed=args.seed[3] if hasattr(args, "seed") else None,
+                )
+                if pretrain_results is not None:
+                    results["results"].update(pretrain_results.get("results", {}))
         except Exception as e:
             eval_logger.error(f"Error in pretrain evaluation: {str(e)}")
 
@@ -229,6 +242,16 @@ def cli_evaluate(args: Optional[argparse.Namespace] = None) -> None:
         parser = setup_custom_parser()
         args = parse_eval_args(parser)
 
+    if args.config is not None:
+        # This overwrites `--tasks` and `--batch_size`
+        with open(args.config, "r") as file:
+            tasks_yaml = yaml.safe_load(file)
+        args.tasks = ','.join([t['task_name'] for t in tasks_yaml['tasks']])
+        batch_sizes_list = [t['batch_size'] for t in tasks_yaml['tasks']]
+        args.annotator_model = tasks_yaml.get('annotator_model', args.annotator_model)
+    else:
+        batch_sizes_list = [args.batch_size for _ in range(len(args.tasks.split(",")))]
+
     # Initialize evaluation tracker
     if args.output_path:
         args.hf_hub_log_args += f",output_path={args.output_path}"
@@ -258,7 +281,7 @@ def cli_evaluate(args: Optional[argparse.Namespace] = None) -> None:
 
     # Initialize model
     try:
-        lm = initialize_model(args.model, args.model_args, args.batch_size, args.max_batch_size)
+        lm = initialize_model(args.model, args.model_args)
     except Exception as e:
         utils.eval_logger.error(f"Failed to initialize model: {str(e)}")
         sys.exit(1)
@@ -289,13 +312,14 @@ def cli_evaluate(args: Optional[argparse.Namespace] = None) -> None:
         task_manager=task_manager,
         pretrain_task_manager=pretrain_task_manager,
         task_list=task_list,
+        batch_sizes_list=batch_sizes_list,
         verbosity=args.verbosity,
         args=args,
     )
 
     # Add metadata to results
     if lm.rank == 0:
-        add_results_metadata(results, args, lm)
+        add_results_metadata(results, batch_sizes_list, args, lm)
         handle_evaluation_output(results, args, evaluation_tracker, wandb_logger)
 
     if dist.is_initialized():
@@ -324,8 +348,6 @@ def setup_evaluation_tracker(output_path: str, use_database: bool) -> DCEvaluati
 def initialize_model(
     model: Union[str, LM],
     model_args: Optional[str] = None,
-    batch_size: int = None,
-    max_batch_size: Optional[int] = None,
     device: Optional[str] = None,
 ) -> LM:
     """
@@ -338,10 +360,6 @@ def initialize_model(
         model_args (Optional[str], optional):
             Additional arguments for model initialization as a string.
             Only used if model is provided as a string. Defaults to None.
-        batch_size (Optional[int], optional):
-            Batch size for model inference. Defaults to None.
-        max_batch_size (Optional[int], optional):
-            Maximum allowed batch size. Defaults to None.
         device (Optional[str], optional):
             Device to load the model on (e.g., 'cuda', 'cpu'). Defaults to None.
 
@@ -355,8 +373,6 @@ def initialize_model(
             model_args = ""
 
         config = {
-            "batch_size": batch_size,
-            "max_batch_size": max_batch_size,
             "device": device,
         }
 
@@ -371,7 +387,7 @@ def initialize_model(
     return lm
 
 
-def add_results_metadata(results: Dict, args: argparse.Namespace, lm: LM) -> None:
+def add_results_metadata(results: Dict, batch_sizes_list: List[int], args: argparse.Namespace, lm: LM) -> None:
     """
     Add metadata and configuration to results.
 
@@ -380,6 +396,8 @@ def add_results_metadata(results: Dict, args: argparse.Namespace, lm: LM) -> Non
             Dictionary of evaluation results to be augmented with metadata.
             The function will modify this dictionary in-place to add
             configuration and runtime information.
+        batch_sizes_list (List[int]):
+            List of batch sizes for each task.
         args (argparse.Namespace):
             Command line arguments containing runtime configuration
             and parameters used during evaluation.
@@ -398,8 +416,8 @@ def add_results_metadata(results: Dict, args: argparse.Namespace, lm: LM) -> Non
             else args.model.config._name_or_path if hasattr(args.model, "config") else type(args.model).__name__
         ),
         "model_args": args.model_args,
-        "batch_size": args.batch_size,
-        "batch_sizes": (list(lm.batch_sizes.values()) if hasattr(lm, "batch_sizes") else []),
+        "tasks": args.tasks,
+        "batch_sizes": batch_sizes_list,
         "device": args.device,
         "use_cache": args.use_cache,
         "limit": args.limit,


### PR DESCRIPTION
Use config yamls so we can keep our evaluation setups consistent. This automatically parses `--tasks`, `--batch_size`, and `--annotator_model` from the yaml file.

```bash
python -m eval.eval \
    --model hf \
    --model_args "pretrained=mistralai/Mistral-7B-Instruct-v0.3" \
    --output_path logs \
    --config configs/light_gpt4omini0718.yaml
```

One other thing in this PR is supporting variable batch sizes for different tasks. See `configs/light_gpt4omini0718.yaml` for example