### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dependencies = [
     "tree_sitter",
     "asttokens",
     "mypy_extensions",
+    "pyext@git+https://github.com/penfever/PyExt",
     
     # Web & API
     "fastapi>=0.101.0",
@@ -104,7 +105,7 @@ dependencies = [
     "requests>=2.28",
     "websocket",
     "aiofiles",
-    "bespokelabs-curator>=0.16.0",
+    "bespokelabs-curator",
     
     # Database
     "sqlalchemy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ dependencies = [
     "requests>=2.28",
     "websocket",
     "aiofiles",
-    "bespokelabs-curator",
+    "bespokelabs-curator>=0.1.16.0",
     
     # Database
     "sqlalchemy",


### PR DESCRIPTION
Proposing 2 changes to the TOML:

1. The strict version requirement for bespokelabs-curator was failing for me; I'd suggest relaxing it if possible.
2. LiveBench has an additional dependency, PyExt. Unfortunately this is a very old package and the latest mainline release isn't compatible with post 3.10 versions of Python. I forked it and created a new release which should be compatible with 3.11 and up, and added it to the TOML.