### PR TITLE
Fix: truncate model identifier in case model name is too long

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -462,7 +462,14 @@ def initialize_model(
     else:
         lm = model
 
-    lm.model_identifier = sanitize_model_name(f"model_{model}_model_args_{model_args}")
+    # For model names that are too long, truncate them to avoid issues with storage
+    if len(f"model_{model}_model_args_{model_args}") > 150:
+        model_name = f"model_{model}_model_args_{model_args}"[:100]
+    else:
+        model_name = f"model_{model}_model_args_{model_args}"
+
+    lm.model_identifier = sanitize_model_name(model_name)
+    
     return lm
 
 


### PR DESCRIPTION
As per title, this PR fixes an issue where at the end of evaluation saving and loading model answer fails due to filename being too long (typically, when one passes many arguments for vLLM)

This PR fixes this by simply truncating the `model_identifier` to something small in order to avoid this issue

Tested it on MTBench

