### PR TITLE
Optimize Evaluation Workflow for Better Batching and Model Reuse For benchmarks with n_repeat > 1

### DIFF
--- a/eval/chat_benchmarks/AIME24/eval_instruct.py
+++ b/eval/chat_benchmarks/AIME24/eval_instruct.py
@@ -61,9 +61,8 @@ class AIME24Benchmark(BaseBenchmark):
         examples = self.load_questions()
         # Prepare instances for model
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -98,10 +97,13 @@ class AIME24Benchmark(BaseBenchmark):
 
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for AIME24...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for AIME24...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None

--- a/eval/chat_benchmarks/AIME25/eval_instruct.py
+++ b/eval/chat_benchmarks/AIME25/eval_instruct.py
@@ -60,9 +60,8 @@ class AIME25Benchmark(BaseBenchmark):
         examples = self.load_questions()
         # Prepare instances for model
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -97,10 +96,13 @@ class AIME25Benchmark(BaseBenchmark):
 
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for AIME25...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for AIME25...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None

--- a/eval/chat_benchmarks/AMC23/eval_instruct.py
+++ b/eval/chat_benchmarks/AMC23/eval_instruct.py
@@ -72,9 +72,9 @@ class AMC23Benchmark(BaseBenchmark):
             model_name = model.model_args["model"]
 
         all_outputs = []
+        all_instances = []
         for i in range(self.n_repeat):
             seed = [s + i for s in self.seed]
-            all_instances = []
             for idx, example in enumerate(examples):
                 messages = [
                     {"role": "user", "content": PROMPT.format(problem=example["question"])},
@@ -107,11 +107,13 @@ class AMC23Benchmark(BaseBenchmark):
 
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for AMC23...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for AMC23...")
+        all_outputs = self.compute(model, all_instances)
 
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None

--- a/eval/chat_benchmarks/CodeElo/eval_instruct.py
+++ b/eval/chat_benchmarks/CodeElo/eval_instruct.py
@@ -130,9 +130,8 @@ class CodeEloBenchmark(BaseBenchmark):
             return html_output
 
         instruction = """"You are a coding expert. Given a competition-level coding problem, you need to write a Python program to solve it. You may start by outlining your thought process. In the end, please provide the complete code in a code block enclosed with ``` ```. The code should take stdin as input and print the output."""
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -158,10 +157,13 @@ class CodeEloBenchmark(BaseBenchmark):
                 instance.repeat_idx = i
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for CodeElo...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for CodeElo...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
 
         # Return None early for non-primary ranks
         if model.rank != 0:

--- a/eval/chat_benchmarks/CodeForces/eval_instruct.py
+++ b/eval/chat_benchmarks/CodeForces/eval_instruct.py
@@ -123,8 +123,8 @@ class CodeForcesBenchmark(BaseBenchmark):
 
         instruction = """You are a coding expert. Given a competition-level coding problem, you need to write a Python program to solve it. You may start by outlining your thought process. In the end, please provide the complete code in a code block enclosed with ``` ```. The code should take stdin as input and print the output. Your program should be a Python function generated from the given prompt. Simply call the function after the definition."""
 
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -150,10 +150,13 @@ class CodeForcesBenchmark(BaseBenchmark):
                 instance.repeat_idx = i
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for CodeForces...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for CodeForces...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
 
         # Return None early for non-primary ranks
         if model.rank != 0:

--- a/eval/chat_benchmarks/GPQADiamond/eval_instruct.py
+++ b/eval/chat_benchmarks/GPQADiamond/eval_instruct.py
@@ -77,9 +77,8 @@ class GPQADiamondBenchmark(BaseBenchmark):
             model_name = model.model_args["model"]
 
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -111,10 +110,13 @@ class GPQADiamondBenchmark(BaseBenchmark):
                 instance.repeat_idx = i
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for GPQADiamond...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for GPQADiamond...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
 
         # Return None early for non-primary ranks
         if model.rank != 0:

--- a/eval/chat_benchmarks/HLE/eval_instruct.py
+++ b/eval/chat_benchmarks/HLE/eval_instruct.py
@@ -98,9 +98,8 @@ class HLESubsetBenchmark(BaseBenchmark):
 
         # Prepare instances for model
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -133,10 +132,13 @@ class HLESubsetBenchmark(BaseBenchmark):
 
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for HLE...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for HLE...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None

--- a/eval/chat_benchmarks/HMMT/eval_instruct.py
+++ b/eval/chat_benchmarks/HMMT/eval_instruct.py
@@ -64,9 +64,8 @@ class HMMTBenchmark(BaseBenchmark):
         examples = self.load_questions()
         # Prepare instances for model
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -101,10 +100,13 @@ class HMMTBenchmark(BaseBenchmark):
 
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for HMMT...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for HMMT...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None

--- a/eval/chat_benchmarks/JEEBench/eval_instruct.py
+++ b/eval/chat_benchmarks/JEEBench/eval_instruct.py
@@ -118,9 +118,8 @@ class JEEBenchBenchmark(BaseBenchmark):
 
         # Prepare instances for model
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -154,10 +153,13 @@ class JEEBenchBenchmark(BaseBenchmark):
 
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for JEEBench...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for JEEBench...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None

--- a/eval/chat_benchmarks/LiveCodeBench/eval_instruct.py
+++ b/eval/chat_benchmarks/LiveCodeBench/eval_instruct.py
@@ -85,9 +85,8 @@ class LiveCodeBenchBenchmark(BaseBenchmark):
             examples = examples[:10]
 
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -122,10 +121,13 @@ class LiveCodeBenchBenchmark(BaseBenchmark):
                 instance.repeat_idx = i
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for LiveCodeBench...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for LiveCodeBench...")
+        all_outputs = self.compute(model, all_instances)
+
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
 
         # Return None early for non-primary ranks
         if model.rank != 0:

--- a/eval/chat_benchmarks/LiveCodeBenchv5/eval_instruct.py
+++ b/eval/chat_benchmarks/LiveCodeBenchv5/eval_instruct.py
@@ -81,9 +81,8 @@ class LiveCodeBenchV5Benchmark(BaseBenchmark):
             examples = examples[:10]
 
         all_outputs = []
-
+        all_instances = []
         for i in range(self.n_repeat):
-            all_instances = []
             seed = [s + i for s in self.seed]
 
             for idx, example in enumerate(examples):
@@ -118,11 +117,13 @@ class LiveCodeBenchV5Benchmark(BaseBenchmark):
                 instance.repeat_idx = i
                 all_instances.append(instance)
 
-            # Generate model responses
-            self.logger.info("Generating responses for LiveCodeBenchV5...")
-            outputs = self.compute(model, all_instances)
-            all_outputs.append(outputs)
+        # Generate model responses
+        self.logger.info("Generating responses for LiveCodeBenchV5...")
+        all_outputs = self.compute(model, all_instances)
 
+        all_outputs = [
+            all_outputs[i: i + len(examples)] for i in range(0, len(examples) * self.n_repeat, len(examples))
+        ]
         # Return None early for non-primary ranks
         if model.rank != 0:
             return None


### PR DESCRIPTION
The current Evalchemy evaluation workflow for banchmarks with n_repeat > 1 is highly inefficient:
```
# Current inefficient approach
for i in range(n_repeat):
    evaluate()  # Reloads model every iteration
```
### Key inefficiencies

- Model reloading overhead: Models are loaded/unloaded n_repeat times, wasting significant time and GPU memory cycling
- Poor batching: Small benchmarks like AIME24/AIME25 (30 samples) result in tiny batches that underutilize GPU resources

### Solution
Restructure the evaluation workflow to load model once and batch across all repeats:

### Key Improvements

- Single model loading: Load model once for all evaluation repeats
- Enhanced batching: Combine samples across repeats for larger, more efficient batches
- Memory efficiency: Eliminate repeated model loading/unloading cycles
- Better GPU utilization: Larger batches maximize hardware throughput

### Speedup
Tests on a 7B reasoning model using AIME24 with n_repeat=8, max_new_tokens=32k, and batch_size set to n_repeat * num_samples (i.e., total samples, so that vLLM processes all instances at once and handles batching) show nearly an 8× speedup.
