### PR TITLE
Fix vLLM crash when max_gen_toks exceeds model context window

### DIFF
--- a/eval/task.py
+++ b/eval/task.py
@@ -15,8 +15,8 @@ import torch.distributed as dist
 from lm_eval.api.instance import Instance
 from lm_eval.api.model import LM
 
-# Safety buffer for vLLM max_gen_toks calculation
-VLLM_SAFETY_BUFFER_TOKENS = 16
+# Safety buffer for max_gen_toks calculation
+SAFETY_BUFFER_TOKENS = 16
 
 
 class BaseBenchmark(ABC):
@@ -49,20 +49,18 @@ class BaseBenchmark(ABC):
                     _ = instance.args[1].pop("seed") if "seed" in instance.args[1] else None
             if "max_new_tokens" in instance.args[1]:
                 max_new_tokens = instance.args[1].pop("max_new_tokens")
-                if isinstance(model, lm_eval_models.openai_completions.OpenAIChatCompletion) or isinstance(
-                    model, lm_eval_models.openai_completions.OpenAICompletionsAPI
-                ):
-                    instance.args[1]["max_tokens"] = max_new_tokens
-                    if "4o" in model.model:
-                        instance.args[1]["max_tokens"] = min(max_new_tokens, 16384)
-                elif isinstance(model, lm_eval_models.vllm_causallms.VLLM):
+                
+                max_model_len = None
+                if isinstance(model, lm_eval_models.vllm_causallms.VLLM):
+                    max_model_len = model.model.llm_engine.model_config.max_model_len
+                elif isinstance(model, lm_eval_models.huggingface.HFLM):
+                    max_model_len = model.model.config.max_position_embeddings
+
+                if max_model_len is not None:
                     try:
                         # Get prompt from instance.args[0] (the templated string)
                         prompt = instance.args[0]
                         prompt_length = len(model.tokenizer.encode(prompt))
-
-                        # Get max model length from vLLM engine
-                        max_model_len = model.model.llm_engine.model_config.max_model_len
 
                         # Check if prompt itself exceeds model capacity
                         if prompt_length > max_model_len:
@@ -72,7 +70,7 @@ class BaseBenchmark(ABC):
                             )
 
                         # Calculate max allowed generation tokens (16 token safety buffer)
-                        max_allowed = max_model_len - prompt_length - VLLM_SAFETY_BUFFER_TOKENS
+                        max_allowed = max_model_len - prompt_length - SAFETY_BUFFER_TOKENS
                         capped_max_new_tokens = min(max_new_tokens, max(1, max_allowed))
 
                         if capped_max_new_tokens < max_new_tokens:
@@ -81,14 +79,23 @@ class BaseBenchmark(ABC):
                                 f"(prompt: {prompt_length} tokens, model max: {max_model_len})"
                             )
 
-                        instance.args[1]["max_gen_toks"] = capped_max_new_tokens
+                        max_new_tokens = capped_max_new_tokens
                     except Exception as e:
                         self.logger.warning(
-                            f"Failed to calculate max_gen_toks for vLLM, using original value: {e}"
+                            f"Failed to calculate max_new_tokens, using original value: {e}"
                         )
-                        instance.args[1]["max_gen_toks"] = max_new_tokens
+                        
+                if isinstance(model, lm_eval_models.openai_completions.OpenAIChatCompletion) or isinstance(
+                    model, lm_eval_models.openai_completions.OpenAICompletionsAPI
+                ):
+                    instance.args[1]["max_tokens"] = max_new_tokens
+                    if "4o" in model.model:
+                        instance.args[1]["max_tokens"] = min(max_new_tokens, 16384)
+                elif isinstance(model, lm_eval_models.vllm_causallms.VLLM):
+                    instance.args[1]["max_gen_toks"] = int(max_new_tokens)
                 else:  # Huggingface
-                    instance.args[1]["max_new_tokens"] = max_new_tokens
+                    instance.args[1]["max_new_tokens"] = int(max_new_tokens)
+
         return instances
 
     def _prepare_messages(

--- a/eval/task.py
+++ b/eval/task.py
@@ -15,6 +15,9 @@ import torch.distributed as dist
 from lm_eval.api.instance import Instance
 from lm_eval.api.model import LM
 
+# Safety buffer for vLLM max_gen_toks calculation
+VLLM_SAFETY_BUFFER_TOKENS = 16
+
 
 class BaseBenchmark(ABC):
     """Abstract base class for implementing LLM evaluation benchmarks."""
@@ -53,26 +56,37 @@ class BaseBenchmark(ABC):
                     if "4o" in model.model:
                         instance.args[1]["max_tokens"] = min(max_new_tokens, 16384)
                 elif isinstance(model, lm_eval_models.vllm_causallms.VLLM):
-                    # Get prompt from instance.args[0] (the templated string)
-                    prompt = instance.args[0]
-                    prompt_length = len(model.tokenizer.encode(prompt))
+                    try:
+                        # Get prompt from instance.args[0] (the templated string)
+                        prompt = instance.args[0]
+                        prompt_length = len(model.tokenizer.encode(prompt))
 
-                    # Get max model length from vLLM engine
-                    max_model_len = model.model.llm_engine.model_config.max_model_len
+                        # Get max model length from vLLM engine
+                        max_model_len = model.model.llm_engine.model_config.max_model_len
 
-                    # Calculate max allowed generation tokens (16 token safety buffer)
-                    max_allowed = max_model_len - prompt_length - 16
+                        # Check if prompt itself exceeds model capacity
+                        if prompt_length > max_model_len:
+                            self.logger.warning(
+                                f"Prompt length ({prompt_length}) exceeds model max length ({max_model_len}). "
+                                f"Prompt will be truncated with no room for generation."
+                            )
 
-                    # Cap to available space
-                    capped_max_new_tokens = min(max_new_tokens, max(1, max_allowed))
+                        # Calculate max allowed generation tokens (16 token safety buffer)
+                        max_allowed = max_model_len - prompt_length - VLLM_SAFETY_BUFFER_TOKENS
+                        capped_max_new_tokens = min(max_new_tokens, max(1, max_allowed))
 
-                    if capped_max_new_tokens < max_new_tokens:
+                        if capped_max_new_tokens < max_new_tokens:
+                            self.logger.warning(
+                                f"max_new_tokens ({max_new_tokens}) capped to {capped_max_new_tokens} "
+                                f"(prompt: {prompt_length} tokens, model max: {max_model_len})"
+                            )
+
+                        instance.args[1]["max_gen_toks"] = capped_max_new_tokens
+                    except Exception as e:
                         self.logger.warning(
-                            f"max_new_tokens ({max_new_tokens}) capped to {capped_max_new_tokens} "
-                            f"(prompt: {prompt_length} tokens, model max: {max_model_len})"
+                            f"Failed to calculate max_gen_toks for vLLM, using original value: {e}"
                         )
-
-                    instance.args[1]["max_gen_toks"] = capped_max_new_tokens
+                        instance.args[1]["max_gen_toks"] = max_new_tokens
                 else:  # Huggingface
                     instance.args[1]["max_new_tokens"] = max_new_tokens
         return instances

--- a/eval/task.py
+++ b/eval/task.py
@@ -53,7 +53,26 @@ class BaseBenchmark(ABC):
                     if "4o" in model.model:
                         instance.args[1]["max_tokens"] = min(max_new_tokens, 16384)
                 elif isinstance(model, lm_eval_models.vllm_causallms.VLLM):
-                    instance.args[1]["max_gen_toks"] = max_new_tokens
+                    # Get prompt from instance.args[0] (the templated string)
+                    prompt = instance.args[0]
+                    prompt_length = len(model.tokenizer.encode(prompt))
+
+                    # Get max model length from vLLM engine
+                    max_model_len = model.model.llm_engine.model_config.max_model_len
+
+                    # Calculate max allowed generation tokens (16 token safety buffer)
+                    max_allowed = max_model_len - prompt_length - 16
+
+                    # Cap to available space
+                    capped_max_new_tokens = min(max_new_tokens, max(1, max_allowed))
+
+                    if capped_max_new_tokens < max_new_tokens:
+                        self.logger.warning(
+                            f"max_new_tokens ({max_new_tokens}) capped to {capped_max_new_tokens} "
+                            f"(prompt: {prompt_length} tokens, model max: {max_model_len})"
+                        )
+
+                    instance.args[1]["max_gen_toks"] = capped_max_new_tokens
                 else:  # Huggingface
                     instance.args[1]["max_new_tokens"] = max_new_tokens
         return instances


### PR DESCRIPTION
## Summary

Fixes #152 by dynamically capping `max_gen_toks` to fit within the model's context window when using vLLM backend.

## Problem Solved

- vLLM backend crashes with `ValueError: please provide at least one prompt` when `max_gen_toks` exceeds `max_model_len - prompt_length`
- This happens because vLLM truncates prompts to make room for generation tokens, resulting in empty prompts

## Changes

**File Modified:** `eval/task.py`

## Key Improvements

1. **Graceful handling**: Caps `max_gen_toks` instead of crashing
2. **Safety buffer**: Uses 16-token buffer to account for special tokens or tokenization edge cases
3. **Warning logs**: Logs when capping occurs for debugging visibility

## Code Changes

```python
# Before
elif isinstance(model, lm_eval_models.vllm_causallms.VLLM):
    instance.args[1]["max_gen_toks"] = max_new_tokens

# After
elif isinstance(model, lm_eval_models.vllm_causallms.VLLM):
    prompt = instance.args[0]
    prompt_length = len(model.tokenizer.encode(prompt))
    max_model_len = model.model.llm_engine.model_config.max_model_len
    
    # Calculate max allowed generation tokens (16 token safety buffer)
    max_allowed = max_model_len - prompt_length - 16
    capped_max_new_tokens = min(max_new_tokens, max(1, max_allowed))
    
    if capped_max_new_tokens < max_new_tokens:
        self.logger.warning(
            f"max_new_tokens ({max_new_tokens}) capped to {capped_max_new_tokens} "
            f"(prompt: {prompt_length} tokens, model max: {max_model_len})"
        )
    
    instance.args[1]["max_gen_toks"] = capped_max_new_tokens
```

## Testing

```bash
# Test with vLLM - should now work instead of crashing
python -m eval.eval --model vllm --tasks MATH500 \
  --model_args "trust_remote_code=True,pretrained=ali-elganzory/1.7b-MixtureVitae-300BT-v1-DPO-Tulu3"

# Verify same model works with hf backend (baseline)
python -m eval.eval --model hf --tasks MATH500 \
  --model_args "trust_remote_code=True,pretrained=ali-elganzory/1.7b-MixtureVitae-300BT-v1-DPO-Tulu3"
```

## Impact

- [x] Prevents runtime crashes from context window overflow
- [x] Better error handling with informative warnings
- [x] No functional changes to working cases (only triggers when needed)
- [x] Works across all benchmarks without per-benchmark fixes